### PR TITLE
Allow Sidekiq v4

### DIFF
--- a/freekiqs.gemspec
+++ b/freekiqs.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name                  = 'freekiqs'
-  gem.version               = '0.2.0'
+  gem.version               = '4.0.0'
   gem.authors               = ['Rob Lewis']
   gem.email                 = ['rob@bookbub.com']
   gem.summary               = 'Sidekiq middleware extending RetryJobs to allow silient errors.'
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.require_paths         = ['lib']
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency             'sidekiq', '>= 1.0.0', '< 4.0.0'
+  gem.add_dependency             'sidekiq', '>= 4.0.0', '< 5.0.0'
   gem.add_development_dependency 'rspec', '>= 2.14.1'
 end

--- a/spec/freekiqs_spec.rb
+++ b/spec/freekiqs_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'celluloid'  # Getting error without this required. Should remove once this supports Sidekiq 4.x
 require 'sidekiq/cli'
 require 'sidekiq/middleware/server/retry_jobs'
 


### PR DESCRIPTION
Looks like lello is pinned to the 0.2 version of freekiqs so I think its safe to merge this in. We'll keep testing out this & SideKiq v4 in pulp on staging, but feel appropriate to move this forward.
