### PR TITLE
Switch sidekiq_options to use getter (get_sidekiq_options)

### DIFF
--- a/lib/sidekiq/middleware/server/freekiqs.rb
+++ b/lib/sidekiq/middleware/server/freekiqs.rb
@@ -37,9 +37,9 @@ module Sidekiq
         def get_freekiqs_if_enabled(worker, msg)
           freekiqs = nil
           if msg['retry']
-            if worker.class.sidekiq_options['freekiqs'] != false
-              if worker.class.sidekiq_options['freekiqs']
-                freekiqs = worker.class.sidekiq_options['freekiqs'].to_i
+            if worker.class.get_sidekiq_options['freekiqs'] != false
+              if worker.class.get_sidekiq_options['freekiqs']
+                freekiqs = worker.class.get_sidekiq_options['freekiqs'].to_i
               elsif @default_freekiqs
                 freekiqs = @default_freekiqs.to_i
               end


### PR DESCRIPTION
We've been seeing this error occasionally 

```
NoMethodError: undefined method 'sidekiq_options_hash' for {WorkerClassName}:Class Did you mean? sidekiq_options_hash? sidekiq_options_hash= sidekiq_options
```

I found this issue thread which suggested replacing `sidekiq_options`, which is a setter, with `get_sidekiq_options`, which a getter: https://github.com/mperham/sidekiq/issues/2302, so trying that out. Ran the tests locally and they passed.
