### PR TITLE
Update Nix and CI to use Ruby 3.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,0 @@
-machine:
-  ruby:
-    version: 3.1.4
-  services:
-    - redis

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,5 @@
 machine:
   ruby:
-    version: 2.3.4
+    version: 3.1.4
   services:
     - redis

--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,9 @@
 { system ? builtins.currentSystem }:
 
 with (import (fetchTarball {
-  name = "nixpkgs-21.11";
-  url = "https://github.com/nixos/nixpkgs/archive/21.11.tar.gz";
-  sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
+  name = "nixpkgs-23.05";
+  url = "https://github.com/nixos/nixpkgs/archive/23.05.tar.gz";
+  sha256 = "10wn0l08j9lgqcw8177nh2ljrnxdrpri7bp0g7nvrsn9rkawvlbf";
 }) { inherit system; });
 
 
@@ -24,7 +24,7 @@ else
       cacert
 
       # Ruby and Rails dependencies
-      ruby_2_7.devEnv
+      ruby_3_1
       bundler
 
       # Services


### PR DESCRIPTION
This sets up local development to use ruby 3.1.4 in nix.

Nix is updated to nixpkgs-23.05 to support this.

The Circle CI configuration is also updated to run ruby 3.1.