### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [3.1, 3.2]
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake


### PR DESCRIPTION
This sets up a GitHub action to run the gem's tests when a pull request is created and on pushes to the main branch.

Tests are run in a test matrix that tests ruby versions 3.1 and 3.2. Should we want to test against the development release of ruby (head), this also includes the ability to allow that to fail without CI failing. That will give us the information that this currently fails, should head be released, without needing to take action, because it is not released.

However, head is not currently part of the test matrix.

Redis is set up according to GitHub's [redis documentation](https://docs.github.com/en/actions/using-containerized-services/creating-redis-service-containers).