### PR TITLE
Test using Sidekiq's fake testing mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,18 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-      redis:
-        image: redis
-        # Set health checks to wait until redis has started
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # Maps port 6379 on service container to the host
-          - 6379:6379
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Previously, the test suite relied on Sidekiq internals to queue and perform jobs and retrieve them from the retry set. This also required a round-trip to redis, given how Sidekiq's retry mechanism works (adding the job payload to a separate [retry redis queue](https://github.com/sidekiq/sidekiq/blob/8874e683e4daaef9e919f0e8eb19b41a544f9073/lib/sidekiq/job_retry.rb#L192).

This use of Sidekiq internals caused some difficulty when Sidekiq 7 modified those internals. The middleware itself worked fine; however, the tests required modification to run.

This instead runs the same tests in Sidekiq's [testing mode](https://github.com/sidekiq/sidekiq/wiki/Testing).

By default, testing mode does not have any retry mechanism (as it will run the job inline when draining the queue). This mitigates that by adding some custom middleware for running in test mode. When an exception is raised, it will push the job back onto the worker queue.

These tests use the existing `perform_one` method in Sidekiq's test mode to only execute the first job in the queue. And then inspect the result of the queue after that job is performed. This allows us to inspect the result of the retry. If we used `drain` instead, Sidekiq's test mode would continue executing it until the max retries are exhausted. This is because test mode checks to see if are any jobs to run by [worker name](https://github.com/sidekiq/sidekiq/blob/8874e683e4daaef9e919f0e8eb19b41a544f9073/lib/sidekiq/testing.rb#L241), so the exception will continue adding it to the worker queue and running it until retries are exhausted.

As a result of this, we no longer need to manage interfacing with Sidekiq's `Processor` and reaching into the `RetrySet`. We also don't need Redis at all for tests, because this is all managed in memory.

Because of this, Redis is removed from the CI setup. The Procfile and Redis configuration remains in case people want to run Sidekiq in full for manually testing. However, it is not needed for running the test suite.