### PR TITLE
Drop support for Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.1, 3.2]
+        ruby: [3.2]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
       - uses: actions/checkout@v3

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,7 @@ else
       cacert
 
       # Ruby and Rails dependencies
-      ruby_3_1
+      ruby_3_2
 
       # Services
       overmind


### PR DESCRIPTION
Ruby 3.1 will be end of life on March 31, 2025. Additionally, Sidekiq 8 supports Ruby 3.2.0 as a minimum.

As a result, this drops 3.1 support of freekiqs by removing it from the testing matrix and increasing the nix version to 3.2.