### PR TITLE
Check in Gemfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 tmp
 gemfiles/*.lock
-Gemfile.lock
 .ruby-version
 pkg
 /.bundle

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+PATH
+  remote: .
+  specs:
+    freekiqs (6.5.0)
+      sidekiq (>= 6.5.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    connection_pool (2.5.0)
+    diff-lcs (1.5.0)
+    logger (1.6.6)
+    rack (3.1.11)
+    rake (13.0.6)
+    redis-client (0.24.0)
+      connection_pool
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    sidekiq (7.3.9)
+      base64
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
+
+PLATFORMS
+  arm64-darwin-22
+  arm64-darwin-23
+  x86_64-darwin-17
+  x86_64-darwin-21
+  x86_64-darwin-22
+
+DEPENDENCIES
+  freekiqs!
+  rake
+  rspec (~> 3.6)
+
+BUNDLED WITH
+   2.3.25

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,6 +41,7 @@ PLATFORMS
   x86_64-darwin-17
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   freekiqs!


### PR DESCRIPTION
Historically, it was common practice to not check in the lock file for a gem. However, the current convention has changed. From [bundler](https://bundler.io/man/bundle-install.1.html#THE-GEMFILE-LOCK):

> As a result, you SHOULD check your Gemfile.lock into version control, in both applications and gems.

This stores the Gemfile.lock in version control in accordance with that advice.