### PR TITLE
Test against Ruby 3.2, 3.3, and 3.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.2]
+        ruby: [3.2, 3.3, 3.4]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This adds newer versions of ruby to the Github Actions testing matrix.